### PR TITLE
Add more error detail if it exists on error

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -251,9 +251,12 @@ data = sys.stdin.read().strip().replace("\n",r"\n").replace("\r","")
 data = json.loads(data)
 pull_link = data.get("html_url")
 if not pull_link:
-    print "ERROR updating issue to a pull request: ", data.get("message")
+    print "ERROR updating issue to a pull request: " + data.get("message")
+    for error in data.get("errors", []):
+        if error.get("message"):
+            print "  --> ERROR DETAIL: " + error.get("message")
 else:
     print "Pull Request Opened"
     print pull_link
 ')
-echo $PULL_STATUS
+echo "$PULL_STATUS"


### PR DESCRIPTION
I was getting this error today:

```
ERROR updating issue to a pull request: Validation Failed
```

When I looked into the full response from the pull API, it was this:

```
{
    'message': 'Validation Failed', 
    'errors': [
        {
            'field': 'base', 
            'message': 'base No commits between bitly:master and mrwoof:1740_e2e_root_domains_1740',
            'code': 'custom',
            'resource': 'PullRequest'
       }
   ]
}
```

That was right: I hadn't committed before my push. But the error message "Validation Failed" didn't give any clues about that.

Info from that "errors" list would have been really helpful, so this pull request displays that error info if there is any.
