### PR TITLE
allow PYTHON_CMD or GIT_CMD to be set from the environment

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -181,7 +181,7 @@ if [ -z "$BASE_ACCOUNT" ]; then
 fi
 
 if [ -z "$BASE_REPO" ]; then
-    read -p "github repsitory name (ie: github.com/$BASE_ACCOUNT/___): " BASE_REPO
+    read -p "github repository name (ie: github.com/$BASE_ACCOUNT/___): " BASE_REPO
     $GIT_CMD config gitOpenPull.baseRepo $BASE_REPO
 fi
 


### PR DESCRIPTION
allow PYTHON_CMD or GIT_CMD to be set from the environment, which is useful if the default python is python3
