### PR TITLE
explicitly use python2

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -59,7 +59,7 @@ HELP_TEXT='
 
 '
 
-PYTHON_CMD=${PYTHON_CMD:-$(which python)}
+PYTHON_CMD=${PYTHON_CMD:-$(which python2)}
 if [ -z "$PYTHON_CMD" ] || ! $PYTHON_CMD --version >/dev/null 2>&1 ; then
     echo "unable to find 'python' command"
     exit 1


### PR DESCRIPTION
On systems where python3 is installed, `python` is aliased to `python3`.

On Arch, Ubuntu, and OS X `python2` will always run python v2.x
