### PR TITLE
GITHUB_USER is always needed, so prompt for it even if access token is set

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -21,7 +21,7 @@ HELP_TEXT='
        $ git open-pull [options] [feature_branch]
 
  OPTIONS
-       -u --user   - github username (not needed when passing --token, or using a saved token)
+       -u --user   - github username 
        -p --password - github password (not needed when passing --token, or using a saved token)
        --save - save access token for future use
        -t --token - github oauth token
@@ -190,6 +190,10 @@ if "token" in data:
         $GIT_CMD config gitOpenPull.token "$GITHUB_TOKEN"
     fi
 else
+    if [ -z "$GITHUB_USER" ]; then
+        echo "Github username isn't set. Pass the --user flag to this script or set with \`git config --global github.user YOUR_USER_NAME\` to avoid being prompted"
+        read -p "github username: " GITHUB_USER
+    fi
     echo "... using saved access token"
 fi
 


### PR DESCRIPTION
I didn't have my github.user set in my gitconfig and, although I had an access token, the script tried to push using $GITHUB_USER. This doesn't occur on the first run of the script (or any other run where the access token isn't set) because the script assumes that the github user config is set if the access token is set.

I don't think git-open-pull should set this config, so this fix just displays an informative message along with the normal github username prompt. 

This fixes #5. 
