### PR TITLE
Add -u to git push

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -274,7 +274,7 @@ else
 fi
 
 echo "pushing branch ${FEATURE_BRANCH} to $GITHUB_USER"
-$GIT_CMD push $GITHUB_USER "${FEATURE_BRANCH}" || exit 1
+$GIT_CMD push -u $GITHUB_USER "${FEATURE_BRANCH}" || exit 1
 
 # Github needs a variable amount of time before a new branch
 # can be used to open a pull request. This is usually enough.


### PR DESCRIPTION
Using --set-upstream on the first push makes gits new defaults for push and pull saner.
