### PR TITLE
Proposal: open $EDITOR when creating a new issue

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -283,6 +283,7 @@ if [ -z "$ISSUE_NUMBER" ]; then
             fi
 
             RAW_ISSUE=$(grep -v "^#" "$TMPFILE")
+            rm "$TMPFILE"
             ISSUE_TITLE=$(echo "$RAW_ISSUE" | head -n 1)
             ISSUE_DESCRIPTION=$(echo "$RAW_ISSUE" | tail -n +2)
         fi


### PR DESCRIPTION
This would work basically the same way `git commit` does when a commit message isn't provided on the command line. The first line in the resulting message will be used as the issue title, any subsequent non-comment lines will be used as the issue description.

I imagine there might be some strong feelings about this feature one way or the other, so please feel free to decline this pull request.  I also imagine there might be some strong feelings about this particular implementation (_particularly given that it doesn't actually work correctly right now_).  I'd be happy to learn about better approaches to solving this problem.

One way in which this implementation differs significantly from that of `git commit` is that this will create a random temp file to use, while `git commit` uses a known file location: `.git/COMMIT_EDITMSG` in whatever repo you're committing to.

Thoughts?
