### PR TITLE
Handle non-ASCII branch names

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -117,7 +117,7 @@ if sys.argv[1] == "get_field":
     sys.exit(1)
 
 if sys.argv[1] == "count_branches":
-    matches = [x for x in data if x.get("name") == sys.argv[3]]
+    matches = [x for x in data if x.get("name") == sys.argv[3].decode("utf8", "ignore")]
     print(len(matches))
     sys.exit(0)
 


### PR DESCRIPTION
Right now, `git-open-pull` can't open pull requests for branches with non-ASCII characters in their names because the comparison between available branch names and the current branch name fails because one of the strings is `unicode` (after JSON decoding) and the other is a plain old `str` which can't be automatically converted to `unicode`.

Here's the important part of the transcript:

```
-c:38: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal

Error: branch (99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5) does not exist in mccutchen/git-open-pull
    valid branches are: 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5, master
```

And here's the whole thing:

```
$ ./git-open-pull 
... using saved access token
issue number [99]: 5
rename branch to 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5 [y/n]:
renaming local branch 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé -> 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5
base pull request on [99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5]: 
pushing branch 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5 to mccutchen
Counting objects: 21, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (14/14), done.
Writing objects: 100% (19/19), 4.43 KiB | 0 bytes/s, done.
Total 19 (delta 6), reused 0 (delta 0)
To git@github.com:mccutchen/git-open-pull.git
 * [new branch]      99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5 -> 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5
Branch 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5 set up to track remote branch 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5 from mccutchen by rebasing.
-c:38: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal

Error: branch (99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5) does not exist in mccutchen/git-open-pull
    valid branches are: 99-éñçødîñg-p®øblèmß-bü†-å-bräñçh-ñâmé-åîñ†-øñé_5, master
```
