### PR TITLE
auto-assign PR

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -330,9 +330,10 @@ if [ -z "$ISSUE_NUMBER" ]; then
 
         ISSUE_TITLE=$(python_helper json_escape "$ISSUE_TITLE")
         ISSUE_DESCRIPTION=$(python_helper json_escape "$ISSUE_DESCRIPTION")
+        ASSIGNEE=$(python_helper json_escape "$GITHUB_USER")
 
         endpoint="https://api.github.com/repos/$BASE_ACCOUNT/$BASE_REPO/issues"
-        json="{\"title\": $ISSUE_TITLE, \"body\": $ISSUE_DESCRIPTION}"
+        json="{\"title\": $ISSUE_TITLE, \"body\": $ISSUE_DESCRIPTION, \"assignee\": $ASSIGNEE}"
         ISSUE_JSON=`curl --silent -H "Accept: application/vnd.github-issue.text+json,application/json" --data-binary "$json" "$endpoint?access_token=$GITHUB_TOKEN"`
         ISSUE_NUMBER=$(python_helper get_field "$ISSUE_JSON" number)
         if [ $? != 0 ] || [ -z "ISSUE_NUMBER" ] ; then


### PR DESCRIPTION
It would be great for git-open-pull to auto-assign an issue when you convert it into a PR. That action is a pretty good indication that you are going to work on something, so syncing w/ the assign value will help make the Github UI more effective.
