### PR TITLE
Increase label limit.

### DIFF
--- a/git-open-pull
+++ b/git-open-pull
@@ -305,7 +305,7 @@ if [ -z "$ISSUE_NUMBER" ]; then
 " > "$TMPFILE"
 
         endpoint="https://api.github.com/repos/$BASE_ACCOUNT/$BASE_REPO/labels"
-        REPO_LABELS_JSON=`curl --silent -H "Accept: application/json" "$endpoint?access_token=$GITHUB_TOKEN"`
+        REPO_LABELS_JSON=`curl --silent -H "Accept: application/json" "$endpoint?access_token=$GITHUB_TOKEN&per_page=100"`
         python_helper format_labels "$REPO_LABELS_JSON" >> "$TMPFILE"
 
         echo "


### PR DESCRIPTION
If you have more than 25 labels on a github repo, only the first 25 created will show. This increase the limit to 100.