### PR TITLE
log output on error

### DIFF
--- a/src/cmd/git-open-pull/issues.go
+++ b/src/cmd/git-open-pull/issues.go
@@ -97,8 +97,9 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 	// pre process template
 	if settings.PreProcess != "" {
 		cmd := exec.CommandContext(ctx, settings.PreProcess, tempFile.Name())
-		err = cmd.Run()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
+			log.Printf("error running pre process template: %s:\n  %s", settings.PreProcess, out)
 			return 0, err
 		}
 	}
@@ -120,8 +121,9 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 	// post process template
 	if settings.PostProcess != "" {
 		cmd = exec.CommandContext(ctx, settings.PostProcess, tempFile.Name())
-		err = cmd.Run()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
+			log.Printf("error running post process template: %s:\n  %s", settings.PostProcess, out)
 			return 0, err
 		}
 	}

--- a/src/cmd/git-open-pull/main.go
+++ b/src/cmd/git-open-pull/main.go
@@ -208,8 +208,9 @@ func main() {
 		}
 
 		cmd := exec.CommandContext(ctx, settings.Callback, tempFile.Name())
-		err = cmd.Run()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
+			log.Printf("error on callback: %s:\n   %s", settings.Callback, out)
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
The stderr output from the running of Pre-, Post- and Callback processes is not reported on error. This PR logs that output.

This allows users to understand more what's going wrong when something fails.