### PR TITLE
Provide better error output when a git command errors

### DIFF
--- a/src/cmd/git-open-pull/git_commands.go
+++ b/src/cmd/git-open-pull/git_commands.go
@@ -10,7 +10,11 @@ import (
 func RunGit(ctx context.Context, arg ...string) ([]byte, error) {
 	// log.Printf("run git %s", strings.Join(arg, " "))
 	cmd := exec.CommandContext(ctx, "git", arg...)
-	return cmd.Output()
+	body, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%s running \"git %s\"", err, strings.Join(arg, " "))
+	}
+	return body, nil
 }
 
 func GitFeatureBranch(ctx context.Context) (string, error) {


### PR DESCRIPTION
This makes it easier to track down errors that result from a git command erroring (like when there are no local commits to open up a PR)