### PR TITLE
Changes to branch issue number detection

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -16,19 +16,26 @@ import (
 	"github.com/google/go-github/github"
 )
 
+// DetectIssueNumber parses out an existing issue from passed in branch name.
+// Issue numbers appear at the end of branch names are are separated from the
+// rest of the branch name by an underscore.
+// i.e: somebranch_1234
 func DetectIssueNumber(branch string) int {
 	if branch == "" {
 		return 0
 	}
-	b := strings.Replace(branch, "-", "_", -1)
-	chunks := strings.Split(b, "_")
 
-	for _, index := range []int{len(chunks) - 1, 0} {
-		if n, err := strconv.Atoi(chunks[index]); err == nil && n > 0 {
-			return n
-		}
+	sub := strings.Split(branch, "_")
+	if len(sub) <= 1 {
+		return 0
 	}
-	return 0
+
+	issueNumber, err := strconv.Atoi(sub[len(sub)-1])
+	if err != nil {
+		return 0
+	}
+
+	return issueNumber
 }
 
 func NewIssue(ctx context.Context, client *github.Client, settings *Settings, interactive bool, title, description string, labels []string) (issueNumber int, err error) {

--- a/issues_test.go
+++ b/issues_test.go
@@ -5,19 +5,20 @@ import (
 	"testing"
 )
 
-func TestDetectIssueNumbert(t *testing.T) {
+func TestDetectIssueNumber(t *testing.T) {
 	type testCase struct {
 		branch      string
 		issueNumber int
 	}
 	tests := []testCase{
-		{"1_branch", 1},
+		{"1_branch", 0},
 		{"branch_1", 1},
 		{"branch_2_a", 0},
 		{"branch_2_33", 33},
 		{"1_branch_2", 2},
-		{"1-branch", 1},
+		{"1-branch", 0},
 		{"branch", 0},
+		{"branch-123", 0},
 	}
 	for i, tc := range tests {
 		tc := tc


### PR DESCRIPTION
Change to DetectIssueNumber function to parse issue from a branch
when in the form of <branchname>_<issuenumber>. This will add support
for having numeric endings in branches such as branch-1234, without the
issue being detected as 1234.

Removes support for issue numbers being parsed from branch names of the following patterns:
* `<issuenumber>-<branchname>`
* `<issuenumber>_<branchname>`
* `<branchname>-<issuenumber>`

Fixes: #41