### PR TITLE
bugfix: honor interactive mode when issue num detected

### DIFF
--- a/git-open-pull.go
+++ b/git-open-pull.go
@@ -59,14 +59,19 @@ func GetIssueNumber(ctx context.Context, client *github.Client, settings *Settin
 			return strconv.Atoi(n)
 		}
 	}
-	n, err := input.Ask(fmt.Sprintf("issue number [%d]", detected), "")
-	if err != nil {
-		log.Fatal(err)
+
+	if interactive {
+		n, err := input.Ask(fmt.Sprintf("issue number [%d]", detected), "")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if n == "" {
+			return detected, nil
+		}
+		return strconv.Atoi(n)
 	}
-	if n == "" {
-		return detected, nil
-	}
-	return strconv.Atoi(n)
+
+	return detected, nil
 }
 
 func main() {


### PR DESCRIPTION
# Fix: Honor `-interactive=false` flag when issue number is detected

## Problem
The `-interactive=false` flag was ignored when confirming detected issue numbers, causing the tool to hang waiting for user input instead of proceeding non-interactively.

## Solution
Added proper check for the `interactive` flag before prompting for issue number confirmation. In non-interactive mode, the detected issue number is used automatically.

## Testing
Verified that `-interactive=false` now works without hanging on issue number prompts, making the tool suitable for automation.
